### PR TITLE
Add Perftest example images

### DIFF
--- a/perftest/Dockerfile
+++ b/perftest/Dockerfile
@@ -1,0 +1,37 @@
+# Build image
+FROM ubuntu:18.04 AS build
+
+ARG D_RDMA_CORE_TAG=v31.0
+ARG D_PERFTEST_TAG=4.4-0.29
+
+WORKDIR /root
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq install apt-utils git autotools-dev autoconf libtool build-essential \
+cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config python3-dev cython3
+
+# Compile and install rdma-core
+RUN git clone --branch ${D_RDMA_CORE_TAG} https://github.com/linux-rdma/rdma-core.git
+RUN /bin/bash -c 'cd /root/rdma-core && ./build.sh && cd build && cp -R lib/* /usr/lib && cp -R etc/* /etc/ && cp -R include/* /usr/include/'
+# Compile perftest
+RUN git clone --branch ${D_PERFTEST_TAG} https://github.com/linux-rdma/perftest.git
+RUN /bin/bash -c 'cd /root/perftest && ./autogen.sh && ./configure && make'
+
+# Application image
+FROM ubuntu:18.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq install pciutils net-tools iproute2 libnl-3-dev libnl-route-3-dev
+WORKDIR /root
+
+# Install rdma-core and delete sources
+COPY --from=build /root/rdma-core ./rdma-core
+RUN /bin/bash -c 'cd ./rdma-core/build && cp -R lib/* /usr/lib && cp -R etc/* /etc/ && cp -R include/* /usr/include/'
+RUN rm -rf ./rdma-core
+
+# Install perftest and delete sources
+COPY --from=build /root/perftest ./perftest
+RUN /bin/bash -c 'cd ./perftest && cp ib_* /usr/bin'
+RUN rm -rf ./perftest
+
+ADD ./entrypoint.sh ./
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/perftest/Dockerfile.with-cuda
+++ b/perftest/Dockerfile.with-cuda
@@ -1,0 +1,37 @@
+# Build image
+FROM nvidia/cuda:10.2-devel-ubuntu18.04 AS build
+
+ARG D_RDMA_CORE_TAG=v31.0
+ARG D_PERFTEST_TAG=4.4-0.29
+
+WORKDIR /root
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq install apt-utils git autotools-dev autoconf libtool build-essential \
+cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config python3-dev cython3
+
+# Compile and install rdma-core
+RUN git clone --branch ${D_RDMA_CORE_TAG} https://github.com/linux-rdma/rdma-core.git
+RUN /bin/bash -c 'cd /root/rdma-core && ./build.sh && cd build && cp -R lib/* /usr/lib && cp -R etc/* /etc/ && cp -R include/* /usr/include/'
+# Compile perftest
+RUN git clone --branch ${D_PERFTEST_TAG} https://github.com/linux-rdma/perftest.git
+RUN /bin/bash -c 'cd /root/perftest && export CUDA_H_PATH=/usr/local/cuda/include/cuda.h && ./autogen.sh && ./configure && make'
+
+# Application image
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq install pciutils net-tools iproute2 libnl-3-dev libnl-route-3-dev
+WORKDIR /root
+
+# Install rdma-core and delete sources
+COPY --from=build /root/rdma-core ./rdma-core
+RUN /bin/bash -c 'cd ./rdma-core/build && cp -R lib/* /usr/lib && cp -R etc/* /etc/ && cp -R include/* /usr/include/'
+RUN rm -rf ./rdma-core
+
+# Install perftest and delete sources
+COPY --from=build /root/perftest ./perftest
+RUN /bin/bash -c 'cd ./perftest && cp ib_* /usr/bin'
+RUN rm -rf ./perftest
+
+ADD ./entrypoint.sh ./
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/perftest/README.md
+++ b/perftest/README.md
@@ -1,0 +1,18 @@
+# Perftest example container
+
+This folder contains Dockerfiles which are used to create a basic container
+with both `rdma-core` and `perftest` packages installed.
+
+`Dockerfile`: basic image based on `ubuntu:18.04` with `rdma-core` and `perftest` packages compiled and
+installed from sources
+
+`Dockerfile.with-cuda` : basic image based on `ubuntu:18.04` with cuda libraries, `rdma-core` and `perftest`
+packages compiled and installed from sources.
+`perftest` is compiled with cuda support to support GPU-Direct. To successfully run this container, it is required
+to run on a host with both RDMA supporing NIC and Nvidia GPU with NVIDIA container runtime installed on the host.
+
+## Buid args
+
+`D_RDMA_CORE_TAG`: linux-rdma/rdma-core tag to use
+
+`D_PERFTEST_TAG`: linux-rdma/perftest tag to use

--- a/perftest/entrypoint.sh
+++ b/perftest/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+echo "Welcome to perftest container"
+sleep inf


### PR DESCRIPTION
This commit adds perftest docker images which builds
perftest from upstream sources inside containe,
both with and without cuda.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>